### PR TITLE
Switch to using #![no_std] with alloc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,9 @@
 name = "collect-me"
 version = "0.1.0"
 edition = "2021"
+authors = ["Jaco Malan <jacom@codelog.co.za>"]
+repository = "https://github.com/JacoMalan1/collect-me"
+description = "Additional collections not included in the Rust standard library."
+license = "MIT"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
     missing_debug_implementations,
     missing_docs
 )]
+#![no_std]
 
 //! Extra data-structures relating to data-lookup not defined in the standard library
 
+extern crate alloc;
 /// Tree-like data-structures
 pub mod tree;

--- a/src/tree/binary_tree.rs
+++ b/src/tree/binary_tree.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 /// A binary tree containing key-value pairs where the keys can be ordered.
 ///
 /// It should be noted that for most applications, a [`std::collections::HashMap`] will offer
@@ -81,7 +83,7 @@ where
     /// Returns a reference to the value corresponding to the key.
     pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
-        K: std::borrow::Borrow<Q>,
+        K: core::borrow::Borrow<Q>,
         Q: PartialOrd + Eq,
     {
         self.root.as_ref().and_then(|root| root.get(key))
@@ -90,7 +92,7 @@ where
     /// Returns a mutable reference to the value corresponding to the key.
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
-        K: std::borrow::Borrow<Q>,
+        K: core::borrow::Borrow<Q>,
         Q: PartialOrd + Eq,
     {
         self.root.as_mut().and_then(|root| root.get_mut(key))
@@ -135,13 +137,13 @@ where
                 None
             }
         } else {
-            Some(std::mem::replace(&mut self.value, value))
+            Some(core::mem::replace(&mut self.value, value))
         }
     }
 
     fn get<Q>(&self, key: &Q) -> Option<&V>
     where
-        K: std::borrow::Borrow<Q>,
+        K: core::borrow::Borrow<Q>,
         Q: PartialOrd + Eq,
     {
         if *key == *self.key.borrow() {
@@ -155,7 +157,7 @@ where
 
     fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
-        K: std::borrow::Borrow<Q>,
+        K: core::borrow::Borrow<Q>,
         Q: PartialOrd + Eq,
     {
         if *key == *self.key.borrow() {
@@ -174,7 +176,7 @@ where
     }
 }
 
-impl<K, V> std::ops::Index<&K> for BinaryTree<K, V>
+impl<K, V> core::ops::Index<&K> for BinaryTree<K, V>
 where
     K: PartialOrd + Eq,
 {


### PR DESCRIPTION
We shouldn't need the `std` crate for this library to function. Therefore we should add the `#![no_std]` attribute to the crate and import the `alloc` crate before too many other data-structures are implemented.